### PR TITLE
Add Prolog

### DIFF
--- a/prolog/README.md
+++ b/prolog/README.md
@@ -1,0 +1,28 @@
+# Prolog
+
+[Prolog](https://www.swi-prolog.org/) is a logic programming language---you define the relations in your program, then query the system to see.
+
+# Try Online
+
+The solution can be viewed [here](https://swish.swi-prolog.org/p/Leftpad.pl) online.
+Example:
+
+```prolog
+?- leftpad(0, 5, [1,2,3], Padded).
+Padded = [0, 0, 1, 2, 3] .
+```
+
+# About This Solution
+
+A verified solution can be "wrong" for only two reasons:
+1. The specification is "wrong".
+2. The underlying tools have bugs in them.
+
+However, this program meets the same two criteria: it's "implementation" **is** the specification of left pad, just written in Prolog.
+Put another way, there is no implementation, only the specification.
+So as long the translation of the specification into Prolog is correct, and Prolog itself (SWI-Prolog, in this case) works, then this program must do what the specification says.
+
+# About Me
+
+My name is [Reed Oei](http://reedoei.com), I'm a student in Math and Computer Science at [UIUC](https://illinois.edu/), and I'm interested in theorem provers and programming languages.
+

--- a/prolog/leftpad.pl
+++ b/prolog/leftpad.pl
@@ -1,0 +1,17 @@
+:- use_module(library(clpfd)).
+
+all_equal([], _).
+all_equal([C|T], C) :- all_equal(T, C).
+
+leftpad(C, N, Str, Padded) :-
+    % Check the length requirement
+    length(Str, L),
+    NewL #= max(L, N),
+    length(Padded, NewL),
+
+    % The suffix is Str
+    append(Prefix, Str, Padded),
+
+    % The prefix is all C
+    all_equal(Prefix, C).
+


### PR DESCRIPTION
Let me preface this by saying that Prolog is of course, not *really* a theorem prover; unlike some other examples, there's no SMT solver or anything backing up this submission. That being said, I think it's arguable (and I'll briefly try) that it still counts:

All of the solutions in this repository can be "wrong" for only two reasons, as their implementations have been verified:
1. The specification is "wrong".
2. The underlying tools have bugs in them.

However, this program meets the same two criteria: it's "implementation" **is** the specification of left pad, just written in Prolog. Put another way, there is no implementation, only the specification. So as long my translation of the specification into Prolog is correct, and Prolog itself (SWI-PL, in my case, but I think this will work with others) works, then this program must do what the specification says.