### PR TITLE
Add Rust

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "leftpad"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+contracts = { version = "0.6.3", features = ["mirai_assertions"] }
+mirai-annotations = "1.12.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,14 +20,22 @@ mod tests {
 	use super::leftpad;
 	#[test]
 	fn no_op() {
-		leftpad(b"foo", 3, b'!');
+		assert_eq!(leftpad(b"foo", 3, b'!').as_slice(), b"foo");
 	}
 	#[test]
 	fn zero_len() {
-		leftpad(b"foo", 0, b'!');
+		assert_eq!(leftpad(b"foo", 0, b'!').as_slice(), b"foo");
 	}
 	#[test]
 	fn padded() {
-		leftpad(b"foo", 5, b'!');
+		assert_eq!(leftpad(b"foo", 5, b'!').as_slice(), b"!!foo");
+	}
+	#[test]
+	fn empty_string() {
+		assert_eq!(leftpad(b"", 5, b'!').as_slice(), b"!!!!!");
+	}
+	#[test]
+	fn empty_zero() {
+		assert_eq!(leftpad(b"", 0, b'!').as_slice(), b"");
 	}
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,33 @@
+use contracts::ensures;
+use mirai_annotations::*;
+
+#[ensures(s.len() >= len -> s == ret.as_slice(),
+          "If s is already long enough, the result should be the same")]
+#[ensures(s.len() < len -> ret.len() == len, "If padding happens, the new length is len")]
+#[ensures(ret.ends_with(s), "The result always ends with s")]
+#[ensures(s.len() < len -> ret.starts_with(vec![byte; len - s.len()].as_slice()),
+          "Enough characters at the start are the padding byte")]
+pub fn leftpad(s: &[u8], len: usize, byte: u8) -> Vec<u8> {
+	if s.len() >= len {
+		Vec::from(s)
+	} else {
+		[vec![byte; len - s.len()], s.to_vec()].concat()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::leftpad;
+	#[test]
+	fn no_op() {
+		leftpad(b"foo", 3, b'!');
+	}
+	#[test]
+	fn zero_len() {
+		leftpad(b"foo", 0, b'!');
+	}
+	#[test]
+	fn padded() {
+		leftpad(b"foo", 5, b'!');
+	}
+}


### PR DESCRIPTION
Rust is a language designed to have some compile-time-verifiable safety checks.  [MIRAI](https://github.com/facebookexperimental/MIRAI) is an experimental project to prove more things statically about Rust programs, but I donʼt know if it can be made to prove enough for this project, both because Iʼm not sure it has good enough theorem proving and because Iʼm not sure you can tell it to check all the necessary things statically and report if it canʼt, avoiding all false negatives.

Todo:
- [ ] Run through `cargo mirai --diag=verify` or `cargo mirai --diag=paranoid` and adjust until that passes
- [ ] Verify this actually proves leftpad sufficiently (I *think* MIRAI does that in those modes but Iʼm not sure)
- [ ] Write up a README

When run without MIRAI, which I have, this only checks at runtime instead of statically.