### PR TITLE
Add z3py version

### DIFF
--- a/z3py/README.md
+++ b/z3py/README.md
@@ -1,0 +1,58 @@
+# About Z3
+
+Z3 is a widely used Satisfiability Modulo Theories (SMT) solver. It has APIs available
+in multiple languages including the Python API (z3py) used in this example. The link
+to the Z3 tutorial written by the core developers:
+https://theory.stanford.edu/~nikolaj/programmingz3.html
+
+Z3 is open-source and available at: https://github.com/Z3Prover/z3
+
+# The CSP approach
+
+In this example, I view the leftpad operation as a constraint satisfaction problem (CSP)
+where I describe the implementation of the operation as a list of logical constraints.
+To do so, I use the String and Regex theories readily available in Z3. I then instantiate
+a Z3 solver instance and instruct it to generate a satisfying *model* that contains the 
+string resulting from the leftpad operation.
+
+For the proof, I use the z3py `prove` method which tries to prove the given claim by
+by showing the negation is unsatisfiable. As for the claim, it is simply a logical
+implication where antecedent is the list of constraints corresponding to the leftpad
+operation and the consequent is the list of the three postconditions.
+
+# Running the script
+
+First, install the `z3-solver` Python library: 
+
+```
+$ pip install z3-solver
+```
+
+Then, simply run the `leftpad.py` script as follows:
+
+```
+./leftpad.py 
+```
+
+This will execute the following function calls:
+```
+    print(leftpad("!", 5, "foo"))
+    print(leftpad("!", 2, "foo"))
+    leftpad(do_prove=True)
+```
+
+And should lead to the following output:
+```
+"!!foo"
+"foo"
+proved
+```
+
+# About Me
+
+I am a software engineer at the National Center for Atmospheric Research. As a scientific
+software developer, I have a strong passion to devise and apply formal verification
+techniques in scientific and high-performance computing applications.
+
+Alper Altuntas, 2023.
+https://github.com/alperaltuntas

--- a/z3py/leftpad.py
+++ b/z3py/leftpad.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Alper Altuntas, 2023.
+
+from z3 import *
+
+Max = lambda x, y: If(x > y, x, y)
+
+
+def leftpad(
+        c = String('c'), 
+        l = Int('l'),
+        w = String('w'),
+        do_prove = False):
+    """
+    Implements the leftpad operation by defining it as a
+    constraint satisfaction problem (CSP) which is then
+    solved using a z3py solver instance to obtain the
+    resulting padded string.
+
+    Parameters
+    ----------
+    c : String of length 1.
+        The padding character.
+    l : Int
+        Total length of the padded string
+    w : String
+        The strings to be padded.
+
+    Returns
+    -------
+    res: String
+        padded string
+    """
+
+    if isinstance(c, str):
+        assert len(c) == 1, "The length of c must be 1."
+
+    # padding
+    pad = String("pad")
+
+    # result
+    res = String("res")
+
+    # The list of constraints that define the leftpad problem
+    constraints = And(
+        [
+            # c is a character
+            Length(c) == 1,
+            # If word length is greater than l, pad is empty
+            Implies(Length(w) >= l, pad == ""),
+            # Else, pad consists of c only and len(pad) = l-len(w)
+            Implies(
+                Length(w) < l,
+                And([InRe(pad, Star(Re(c))), Length(pad) == l - Length(w)]),
+            ),
+            # res is concatenation of pad and w:
+            res == pad + w,
+        ]
+    )
+
+    # Solve the constraint satisfaction problem that corresponds the leftpad operation
+    s = Solver()
+    s.add(constraints)
+    s.check()
+
+    if do_prove:
+        postconditions = And(
+            [
+                # The length of the output is max(n, len(str))
+                Length(res) == Max(l, Length(w)),
+                # The prefix of the output is padding characters and nothing but padding characters
+                Or(pad == "", InRe(pad, Star(Re(c)))),
+                # The suffix of the output is the original string.
+                SuffixOf(w, res),
+            ]
+        )
+
+        prove(Implies(constraints, postconditions))
+
+    return s.model()[res]
+
+
+if __name__ == "__main__":
+    print(leftpad("!", 5, "foo"))
+    print(leftpad("!", 2, "foo"))
+    leftpad(do_prove=True)


### PR DESCRIPTION
This PR add a `z3py` version of the leftpad operation. In this version, I view the leftpad operation as a constraint satisfaction problem (CSP) where I describe the implementation of the operation as a list of logical constraints. To do so, I use the String and Regex theories readily available in Z3. I then instantiate a Z3 solver instance and instruct it to generate a satisfying *model* that contains the  string resulting from the leftpad operation.

For the proof, I use the z3py `prove` method which tries to prove the given claim by showing the negation is unsatisfiable. As for the claim, it is simply a logical implication where antecedent is the list of constraints corresponding to the leftpad operation and the consequent is the list of the three postconditions.