### PR TITLE
Lean 4 port

### DIFF
--- a/lean4/.gitignore
+++ b/lean4/.gitignore
@@ -1,0 +1,2 @@
+/build
+/lake-packages/*

--- a/lean4/README.md
+++ b/lean4/README.md
@@ -1,0 +1,45 @@
+# Lean 4 leftpad
+
+This is a port of the `leftpad` function and correctness proofs from the
+now deprecated Lean version 3 to the [Lean 4](https://lean-lang.org/)
+theorem prover.
+
+
+## About Lean 4
+
+Lean 4 is a Dependently-Typed Programming Language designed for verified
+programming, featuring efficient run-time system (with multithreading), flexible
+macro system (with syntactic extensions and elaborator reflections) and some
+advanced type system elements (quotient types, mutual and nested inductive
+types, etc.). Thanks to strict separation of total and non-total functions,
+as well as great interactive development support via VS Code and Emacs plugins,
+Lean 4 also excels as a Proof Assistant to formalizing mathematics as evidenced
+by the [Mathlib](https://github.com/leanprover-community/mathlib4) project.
+
+
+## About the Code
+
+All the code is in [`leftpad.lean`](./leftpad.lean) file. It's split into two
+sections.
+
+The first part is a literal port of the `leftpad` function from the
+Lean 3 [code](../leanprover/leftpad.lean), it's defined in terms of lists of
+arbitrary elements (not necessarily characters).
+
+The second part in the `Strings` namespace defines another version of `leftpad`
+operating on `String`s (which are internally UTF8 strings in Lean 4).
+
+
+## About the Proofs
+
+The proofs a fairly verbose due to two reasons: the major one being me doing
+them in a pretty straightforward and not very smart way, while another one
+is that I only used built-in Lean 4 library, which intentionally very minimal,
+which lead me to prove a number of auxiliary lemmas stating basic properties of
+operations involved in the `leftpad` function and correctness conditions.
+
+
+## About me
+
+I'm Alex Chichigin ([Github](https://github.com/gabriel-fallen/),
+[blog](https://dev.to/gabrielfallen)) a formal methods enthusiast. :)

--- a/lean4/README.md
+++ b/lean4/README.md
@@ -38,6 +38,10 @@ is that I only used built-in Lean 4 library, which intentionally very minimal,
 which lead me to prove a number of auxiliary lemmas stating basic properties of
 operations involved in the `leftpad` function and correctness conditions.
 
+For the proofs (even the statements) of `leftpad_prefix` and `leftpad_suffix`
+for `String`s I kinda cheat and reduce them to the statements on `List Char`
+instead, reusing some lemmas developed for the original `leftpad` proofs.
+
 
 ## About me
 

--- a/lean4/lakefile.lean
+++ b/lean4/lakefile.lean
@@ -1,0 +1,10 @@
+import Lake
+open Lake DSL
+
+package «lean4» {
+  -- add package configuration options here
+}
+
+lean_lib «Lean4» {
+  -- add library configuration options here
+}

--- a/lean4/lean-toolchain
+++ b/lean4/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:4.0.0

--- a/lean4/leftpad.lean
+++ b/lean4/leftpad.lean
@@ -7,44 +7,42 @@ def leftpad (n : Nat) (a : α) (l : List α) : List α :=
 
 #eval List.toString (leftpad 5 'b' (String.toList "ac"))
 
-theorem leftpad_length (n : Nat) (a : α) (l : List α) : (leftpad n a l).length = max n (l.length) := by
+theorem leftpad_length (n : Nat) (a : α) (l : List α) :
+    (leftpad n a l).length = max n (l.length) := by
   simp [leftpad, Nat.max_def]
   unfold ite
   cases (Nat.decLe n (List.length l)) with
   | isTrue h =>
     dsimp
     rw [Nat.sub_eq_zero_of_le]
-    simp
-    assumption
+    . simp
+    . assumption
   | isFalse h =>
     dsimp
     rw [Nat.sub_add_cancel]
     apply Nat.le_of_lt (Nat.gt_of_not_le h)
 
 
-theorem prefix_concat [BEq α] [LawfulBEq α] (l m : List α) : l.isPrefixOf (l ++ m) := by
-  unfold List.isPrefixOf
+theorem prefix_concat [BEq α] [LawfulBEq α] (l m : List α) :
+    l.isPrefixOf (l ++ m) := by
   induction l with
-  | nil =>
-    simp
-  | cons x xs ih =>
-    simp
-    unfold List.isPrefixOf
-    rw [ih]
+  | nil => simp [List.isPrefixOf]
+  | cons x xs ih => simp [List.isPrefixOf, ih]
 
 theorem leftpad_prefix [BEq α] [LawfulBEq α] (n : Nat) (a : α) (l : List α) :
-(List.replicate (n - l.length) a).isPrefixOf (leftpad n a l) := by
+    (List.replicate (n - l.length) a).isPrefixOf (leftpad n a l) := by
   simp [leftpad]
   apply prefix_concat (List.replicate (n - List.length l) a) l
 
 
-theorem suffix_concat [BEq α] [LawfulBEq α] (l m : List α) : m.isSuffixOf (l ++ m) := by
+theorem suffix_concat [BEq α] [LawfulBEq α] (l m : List α) :
+    m.isSuffixOf (l ++ m) := by
   unfold List.isSuffixOf
   rw [List.reverse_append]
   apply prefix_concat (List.reverse m) (List.reverse l)
 
 theorem leftpad_suffix [BEq α] [LawfulBEq α] (n : Nat) (a : α) (l : List α) :
-l.isSuffixOf (leftpad n a l) := by
+    l.isSuffixOf (leftpad n a l) := by
   simp [leftpad]
   apply suffix_concat
 
@@ -57,32 +55,35 @@ def leftpad (n : Nat) (a : Char) (s : String) : String :=
 #eval leftpad 5 'b' "ac"
 
 
-theorem length_append_distrib (s t : String) : (s ++ t).length = s.length + t.length := by
+theorem length_append_distrib (s t : String) :
+    (s ++ t).length = s.length + t.length := by
   simp [HAppend.hAppend, Append.append, String.append, String.length]
 
-theorem length_push_data_succ (s : String) (a : Char) : (s.push a).data.length = s.data.length + 1 := by
+theorem length_push_data_succ (s : String) (a : Char) :
+    (s.push a).data.length = s.data.length + 1 := by
   simp [String.push, String.length]
 
-theorem length_pushn_zero (s : String) (a : Char) : (s.pushn a 0).length = s.length := by
+theorem length_pushn_zero (s : String) (a : Char) :
+    (s.pushn a 0).length = s.length := by
   simp [String.pushn, Nat.repeat]
 
-theorem length_pushn_sub (n : Nat) (s : String) (a : Char) (h : n > 0) : (s.pushn a n).length = s.length + n := by
+theorem length_pushn_sub (n : Nat) (s : String) (a : Char) (h : n > 0) :
+    (s.pushn a n).length = s.length + n := by
   simp [String.length, String.pushn]
   induction n with
-  | zero =>
-    contradiction
+  | zero      => contradiction
   | succ m ih =>
     unfold Nat.repeat
     rw [length_push_data_succ]
     induction m with
-    | zero =>
-      simp [Nat.repeat]
+    | zero   => simp [Nat.repeat]
     | succ k =>
       rw [ih]
-      simp_arith
-      simp_arith
+      . simp_arith
+      . simp_arith
 
-theorem leftpad_length (n : Nat) (a : Char) (s : String) : (leftpad n a s).length = max n (s.length) := by
+theorem leftpad_length (n : Nat) (a : Char) (s : String) :
+    (leftpad n a s).length = max n (s.length) := by
   simp [leftpad, Nat.max_def]
   unfold ite
   cases (Nat.decLe n (String.length s)) with
@@ -103,44 +104,46 @@ theorem leftpad_length (n : Nat) (a : Char) (s : String) : (leftpad n a s).lengt
     . assumption
 
 
-theorem string_data_concat (s t : String) : (s ++ t).data = s.data ++ t.data := by
+theorem string_data_concat (s t : String) :
+    (s ++ t).data = s.data ++ t.data := by
   simp [HAppend.hAppend, Append.append, String.append]
 
-theorem replicate_cons (n : Nat) (a : α) : List.replicate n a ++ [a] = a :: List.replicate n a := by
+theorem replicate_cons (n : Nat) (a : α) :
+    List.replicate n a ++ [a] = a :: List.replicate n a := by
   induction n with
-  | zero => simp [List.replicate]
-  | succ m ih =>
-    simp [List.replicate, ih]
+  | zero      => simp [List.replicate]
+  | succ m ih => simp [List.replicate, ih]
 
-theorem repeat_empty (c : Char) (n : Nat) : (n.repeat (fun s => s.push c) "").data = List.replicate n c := by
+theorem repeat_empty (c : Char) (n : Nat) :
+    (n.repeat (fun s => s.push c) "").data = List.replicate n c := by
   induction n with
-  | zero =>
-    simp [Nat.repeat]
+  | zero      => simp [Nat.repeat]
   | succ m ih =>
     simp [Nat.repeat, String.push]
     simp [String.push] at ih
     rw [ih]
     simp [replicate_cons]
 
-theorem pushn_succ (m : Nat) (a : Char) : ("".pushn a m.succ).data = a :: ("".pushn a m).data := by
+theorem pushn_succ (m : Nat) (a : Char) :
+    ("".pushn a m.succ).data = a :: ("".pushn a m).data := by
   simp [String.pushn, repeat_empty]
 
-theorem pushn_empty_replicate (n : Nat) (a : Char) : ("".pushn a n).data = List.replicate n a := by
+theorem pushn_empty_replicate (n : Nat) (a : Char) :
+    ("".pushn a n).data = List.replicate n a := by
   induction n with
-  | zero =>
-    simp [String.pushn, Nat.repeat]
+  | zero      => simp [String.pushn, Nat.repeat]
   | succ m ih =>
     simp [Nat.repeat]
     rw [<-ih, pushn_succ]
 
 theorem leftpad_prefix (n : Nat) (a : Char) (s : String) :
-(List.replicate (n - s.length) a).isPrefixOf (leftpad n a s).data := by
+    (List.replicate (n - s.length) a).isPrefixOf (leftpad n a s).data := by
   simp [leftpad, string_data_concat]
   rw [pushn_empty_replicate]
   simp [prefix_concat]
 
 
 theorem leftpad_suffix (n : Nat) (a : Char) (s : String) :
-s.data.isSuffixOf (leftpad n a s).data := by
+    s.data.isSuffixOf (leftpad n a s).data := by
   simp [leftpad, string_data_concat]
   apply suffix_concat

--- a/lean4/leftpad.lean
+++ b/lean4/leftpad.lean
@@ -46,4 +46,101 @@ theorem suffix_concat [BEq α] [LawfulBEq α] (l m : List α) : m.isSuffixOf (l 
 theorem leftpad_suffix [BEq α] [LawfulBEq α] (n : Nat) (a : α) (l : List α) :
 l.isSuffixOf (leftpad n a l) := by
   simp [leftpad]
-  apply suffix_concat (List.replicate (n - List.length l) a) l
+  apply suffix_concat
+
+
+namespace Strings
+
+def leftpad (n : Nat) (a : Char) (s : String) : String :=
+  "".pushn a (n - s.length) ++ s
+
+#eval leftpad 5 'b' "ac"
+
+
+theorem length_append_distrib (s t : String) : (s ++ t).length = s.length + t.length := by
+  simp [HAppend.hAppend, Append.append, String.append, String.length]
+
+theorem length_push_data_succ (s : String) (a : Char) : (s.push a).data.length = s.data.length + 1 := by
+  simp [String.push, String.length]
+
+theorem length_pushn_zero (s : String) (a : Char) : (s.pushn a 0).length = s.length := by
+  simp [String.pushn, Nat.repeat]
+
+theorem length_pushn_sub (n : Nat) (s : String) (a : Char) (h : n > 0) : (s.pushn a n).length = s.length + n := by
+  simp [String.length, String.pushn]
+  induction n with
+  | zero =>
+    contradiction
+  | succ m ih =>
+    unfold Nat.repeat
+    rw [length_push_data_succ]
+    induction m with
+    | zero =>
+      simp [Nat.repeat]
+    | succ k =>
+      rw [ih]
+      simp_arith
+      simp_arith
+
+theorem leftpad_length (n : Nat) (a : Char) (s : String) : (leftpad n a s).length = max n (s.length) := by
+  simp [leftpad, Nat.max_def]
+  unfold ite
+  cases (Nat.decLe n (String.length s)) with
+  | isTrue h =>
+    dsimp
+    rw [length_append_distrib ("".pushn a (n - s.length)) s]
+    have z : n - s.length = 0 := Nat.sub_eq_zero_of_le h
+    rw [z, length_pushn_zero]
+    simp [String.length]
+  | isFalse h =>
+    dsimp
+    rw [length_append_distrib ("".pushn a (n - s.length)) s]
+    have ngt : n - s.length > 0 := by
+      simp [Nat.gt_of_not_le h, Nat.sub_ne_zero_of_lt, Nat.zero_lt_sub_of_lt]
+    rw [length_pushn_sub]
+    . simp [String.length]
+      apply Nat.sub_add_cancel (Nat.le_of_lt (Nat.gt_of_not_le h))
+    . assumption
+
+
+theorem string_data_concat (s t : String) : (s ++ t).data = s.data ++ t.data := by
+  simp [HAppend.hAppend, Append.append, String.append]
+
+theorem replicate_cons (n : Nat) (a : α) : List.replicate n a ++ [a] = a :: List.replicate n a := by
+  induction n with
+  | zero => simp [List.replicate]
+  | succ m ih =>
+    simp [List.replicate, ih]
+
+theorem repeat_empty (c : Char) (n : Nat) : (n.repeat (fun s => s.push c) "").data = List.replicate n c := by
+  induction n with
+  | zero =>
+    simp [Nat.repeat]
+  | succ m ih =>
+    simp [Nat.repeat, String.push]
+    simp [String.push] at ih
+    rw [ih]
+    simp [replicate_cons]
+
+theorem pushn_succ (m : Nat) (a : Char) : ("".pushn a m.succ).data = a :: ("".pushn a m).data := by
+  simp [String.pushn, repeat_empty]
+
+theorem pushn_empty_replicate (n : Nat) (a : Char) : ("".pushn a n).data = List.replicate n a := by
+  induction n with
+  | zero =>
+    simp [String.pushn, Nat.repeat]
+  | succ m ih =>
+    simp [Nat.repeat]
+    rw [<-ih, pushn_succ]
+
+theorem leftpad_prefix (n : Nat) (a : Char) (s : String) :
+(List.replicate (n - s.length) a).isPrefixOf (leftpad n a s).data := by
+  simp [leftpad, string_data_concat]
+  rw [pushn_empty_replicate]
+  simp [prefix_concat]
+
+
+theorem leftpad_suffix (n : Nat) (a : Char) (s : String) :
+s.data.isSuffixOf (leftpad n a s).data := by
+  simp [leftpad, string_data_concat]
+  apply suffix_concat

--- a/lean4/leftpad.lean
+++ b/lean4/leftpad.lean
@@ -1,0 +1,49 @@
+
+
+variable {α : Type}
+
+def leftpad (n : Nat) (a : α) (l : List α) : List α :=
+  List.replicate (n - l.length) a ++ l
+
+#eval List.toString (leftpad 5 'b' (String.toList "ac"))
+
+theorem leftpad_length (n : Nat) (a : α) (l : List α) : (leftpad n a l).length = max n (l.length) := by
+  simp [leftpad, Nat.max_def]
+  unfold ite
+  cases (Nat.decLe n (List.length l)) with
+  | isTrue h =>
+    dsimp
+    rw [Nat.sub_eq_zero_of_le]
+    simp
+    assumption
+  | isFalse h =>
+    dsimp
+    rw [Nat.sub_add_cancel]
+    apply Nat.le_of_lt (Nat.gt_of_not_le h)
+
+
+theorem prefix_concat [BEq α] [LawfulBEq α] (l m : List α) : l.isPrefixOf (l ++ m) := by
+  unfold List.isPrefixOf
+  induction l with
+  | nil =>
+    simp
+  | cons x xs ih =>
+    simp
+    unfold List.isPrefixOf
+    rw [ih]
+
+theorem leftpad_prefix [BEq α] [LawfulBEq α] (n : Nat) (a : α) (l : List α) :
+(List.replicate (n - l.length) a).isPrefixOf (leftpad n a l) := by
+  simp [leftpad]
+  apply prefix_concat (List.replicate (n - List.length l) a) l
+
+
+theorem suffix_concat [BEq α] [LawfulBEq α] (l m : List α) : m.isSuffixOf (l ++ m) := by
+  unfold List.isSuffixOf
+  rw [List.reverse_append]
+  apply prefix_concat (List.reverse m) (List.reverse l)
+
+theorem leftpad_suffix [BEq α] [LawfulBEq α] (n : Nat) (a : α) (l : List α) :
+l.isSuffixOf (leftpad n a l) := by
+  simp [leftpad]
+  apply suffix_concat (List.replicate (n - List.length l) a) l


### PR DESCRIPTION
As long as Lean 3 is deprecated now, I ported the code to Lean 4. I also added a version defined in terms of Lean 4 native `String`s.

In the same vein as the previous development, I only use the Lean 4 built-in library. However, it forced me to prove several auxiliary lemmas due to the Lean 4 library intentionally being very minimal, in contrast to Lean 3.  Possible further development might be using Std4 library with lemmas about `String`s to simplify the proofs.