### PR TITLE
Add Quint proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pdf
 *.tlaps
 *.toolbox
+_apalache-out/
 creusot/target
 creusot/Cargo.lock

--- a/quint/leftpad.qnt
+++ b/quint/leftpad.qnt
@@ -1,0 +1,107 @@
+module leftpad {
+  type Char = { code: int }
+
+  pure val CHARS: Set[Char] = Int.map(i => { code: i })
+
+  var c: Char
+  var n: int
+  var s: List[Char]
+  var output: List[Char]
+  var i: int
+
+  pure def max(x: int, y: int): int = if (x > y) x else y
+
+  def pad: int = max(n - s.length(), 0)
+
+  action init = {
+    nondet initC = CHARS.oneOf()
+    nondet initN = Nat.oneOf()
+    nondet initS = CHARS.allLists().oneOf()
+    all {
+      c' = initC,
+      n' = initN,
+      s' = initS,
+      output' = initS,
+      i' = 0,
+    }
+  }
+
+  action prependPad = all {
+    i < pad,
+    c' = c,
+    n' = n,
+    s' = s,
+    output' = [c].concat(output),
+    i' = i + 1,
+  }
+
+  action done = all {
+    i >= pad,
+    c' = c,
+    n' = n,
+    s' = s,
+    output' = output,
+    i' = i,
+  }
+
+  action step = any {
+    prependPad,
+    done,
+  }
+
+  def prefixIsPadding(upTo: int): bool =
+    and {
+      0 <= upTo,
+      upTo <= output.length(),
+      output.indices().forall(j => j < upTo implies output[j] == c),
+    }
+
+  def suffixIsOriginal(offset: int): bool =
+    and {
+      0 <= offset,
+      offset + s.length() <= output.length(),
+      s.indices().forall(j => output[offset + j] == s[j]),
+    }
+
+  def typeOk: bool = and {
+    c.in(CHARS),
+    n.in(Nat),
+    s.in(CHARS.allLists()),
+    output.in(CHARS.allLists()),
+    i.in(Nat),
+    i <= pad,
+  }
+
+  def loopInv: bool = and {
+    typeOk,
+    output.length() == s.length() + i,
+    prefixIsPadding(i),
+    suffixIsOriginal(i),
+  }
+
+  def correctWhenDone: bool =
+    i >= pad implies and {
+      output.length() == max(n, s.length()),
+      prefixIsPadding(pad),
+      suffixIsOriginal(pad),
+    }
+
+  def correct: bool = loopInv and correctWhenDone
+}
+
+module leftpadExamples {
+  import leftpad.*
+
+  action initExample = all {
+    c' = { code: 0 },
+    n' = 5,
+    s' = [{ code: 1 }, { code: 1 }, { code: 0 }],
+    output' = [{ code: 1 }, { code: 1 }, { code: 0 }],
+    i' = 0,
+  }
+
+  run leftpadFive = initExample
+    .then(prependPad)
+    .then(prependPad)
+    .expect(output == [{ code: 0 }, { code: 0 }, { code: 1 }, { code: 1 }, { code: 0 }])
+}

--- a/quint/readme.md
+++ b/quint/readme.md
@@ -1,0 +1,72 @@
+# [Quint](https://quint-lang.org/)
+
+Quint is a specification language for writing executable state-machine models
+and properties. Quint specifications can be simulated with `quint run` or
+`quint test`, and checked with model checkers. The integrated checker used here
+is [Apalache](https://apalache-mc.org/), which translates Quint verification
+conditions to SMT.
+
+## About Quint
+
+Quint looks a lot like a cleaned-up, executable dialect of TLA+. A model has
+state variables, an `init` action, and a `step` action. An action describes a
+relation between the current state and the next state, using primed variables
+such as `output'`.
+
+Quint has ordinary executable tests, but the proof below is not just a test.
+The `verify` command asks Apalache to prove an inductive invariant:
+
+1. The invariant holds in every initial state.
+2. If it holds before a step, it holds after the step.
+3. The invariant implies the desired correctness property.
+
+This is the same proof shape as the TLA+/TLAPS proof, but the proof obligations
+are discharged automatically by Apalache instead of written as a structured
+TLAPS proof.
+
+## About the Proof
+
+This version models leftpad as a small transition system:
+
+1. Choose an arbitrary padding character `c`, target length `n`, and input
+   string `s`.
+2. Start with `output = s` and `i = 0`.
+3. Compute `pad = max(n - s.length(), 0)`.
+4. While `i < pad`, prepend `c` to `output` and increment `i`.
+
+Quint does not have a dedicated character type, so this proof represents a
+character as a record `{ code: int }`. The set of possible characters is
+`CHARS = Int.map(i => { code: i })`, so the proof ranges over infinitely many
+character values and over all finite lists of those characters.
+
+The key inductive invariant is `loopInv`. It says:
+
+1. The variables have the expected domains: `n` and `i` are natural numbers,
+   `c` is a character, and `s` and `output` are finite character lists.
+2. `output.length() == s.length() + i`.
+3. The first `i` elements of `output` are the padding character.
+4. The original input `s` appears after those `i` padding elements.
+
+The checked correctness property is `correct`. When the loop is done, it proves
+the three leftpad requirements:
+
+1. The output length is `max(n, s.length())`.
+2. The prefix contains padding characters and nothing but padding characters.
+3. The suffix is the original input list.
+
+## Checking the Proof
+
+To run one executable example:
+
+```sh
+quint test quint/leftpad.qnt --main leftpadExamples --match leftpadFive
+```
+
+To check the proof:
+
+```sh
+quint typecheck quint/leftpad.qnt
+quint verify quint/leftpad.qnt --inductive-invariant loopInv --invariant correct
+```
+
+The proof command checks the inductive-invariant obligations.


### PR DESCRIPTION
Adds a Quint version of the leftpad proof.

This models leftpad as a transition system and checks the correctness property with an inductive invariant discharged by Apalache. 

Verification:

```sh
quint typecheck quint/leftpad.qnt
quint test quint/leftpad.qnt --main leftpadExamples --match leftpadFive --verbosity=0
quint verify quint/leftpad.qnt --inductive-invariant loopInv --invariant correct --verbosity=0
```