### PR TITLE
Add Groovy proofs (groovy-verify): imperative and functional

### DIFF
--- a/groovy (functional)/leftpad.groovy
+++ b/groovy (functional)/leftpad.groovy
@@ -1,0 +1,46 @@
+import groovy.transform.TypeChecked
+import groovy.contracts.Requires
+import groovy.contracts.Ensures
+import groovy.contracts.Decreases
+
+// Verified at COMPILE TIME by groovy-verify (https://github.com/paulk-asert/groovy-verify).
+// No loops, no mutation: the recursion's own @Ensures is its induction hypothesis (sound
+// because @Decreases proves termination), and the length property is DERIVED by a theorem
+// method from a padding-length lemma — the spec-function / proof-function structure.
+@TypeChecked(extensions = 'verification.VerifyChecker')
+class Leftpad {
+    // The specification is STRUCTURAL: the result IS the padding block followed by the
+    // original string. This single equality pins properties 2 and 3 exactly (prefix is
+    // nothing but pad characters; suffix is s), stronger than the usual index clauses.
+    @Requires({ pad != null && s != null && pad.length() == 1 })
+    @Ensures({ (s.length() >= n ==> result == s) &&
+               (s.length() < n ==> result == pads(pad, n - s.length()) + s) })
+    @Decreases({ n - s.length() })
+    static String leftpad(String pad, int n, String s) {
+        s.length() >= n ? s : pad + leftpad(pad, n - 1, s)
+    }
+
+    // The padding block, defined recursively (a pure "ghost" builder).
+    static String pads(String pad, int k) {
+        k <= 0 ? '' : pad + pads(pad, k - 1)
+    }
+
+    // Lemma: |pads(pad, k)| == k, by induction on k (the recursive call is the hypothesis).
+    @Requires({ pad != null && pad.length() == 1 && k >= 0 })
+    @Ensures({ pads(pad, k).length() == k })
+    @Decreases({ k })
+    static void padsLen(String pad, int k) {
+        if (k > 0) { padsLen(pad, k - 1) }
+    }
+
+    // Theorem: property 1, |leftpad(pad, n, s)| == n when padding happens (== max(n, |s|)
+    // overall, with the identity case giving |s| when |s| >= n). Derived from leftpad's
+    // structural postcondition plus the padsLen lemma: |pads(n-|s|) + s| = (n-|s|) + |s|.
+    @Requires({ pad != null && s != null && pad.length() == 1 && s.length() < n })
+    @Ensures({ result.length() == n })
+    static String lengthTheorem(String pad, int n, String s) {
+        padsLen(pad, n - s.length())
+        return leftpad(pad, n, s)
+    }
+
+}

--- a/groovy (functional)/readme.md
+++ b/groovy (functional)/readme.md
@@ -1,0 +1,45 @@
+# [Groovy (Functional, groovy-verify)](https://github.com/paulk-asert/groovy-verify)
+
+A functional proof of leftpad in [Apache Groovy](https://groovy.apache.org/) — no loops, no
+mutation, recursion + induction — verified at **compile time** by
+[groovy-verify](https://github.com/paulk-asert/groovy-verify) (a static type-checking extension
+that discharges contract annotations with Z3 during compilation). No online demo yet; the proof is
+pinned in groovy-verify's test corpus (the `P211 structural leftpad` group) and reproduces with
+`./gradlew verify`.
+
+## About Groovy and groovy-verify
+
+See the sibling [imperative entry](../groovy/readme.md) for the tool description. The relevant
+extra here: a method's own `@Ensures` is assumed at its recursive call sites — sound because
+`@Decreases` proves the recursion terminates — which is precisely proof by induction. Void methods
+whose only job is to carry an `@Ensures` act as lemmas/theorems: call one, and its (proved) fact
+enters your proof context. That gives Groovy the spec-function / proof-function structure this
+repo's Verus entry uses, with plain methods.
+
+## About the proof
+
+The recursion prepends one pad character to the recursive result, decreasing `n`
+(`pad + leftpad(pad, n - 1, s)`), and its specification is **structural** rather than index-wise:
+
+```groovy
+result == pads(pad, n - s.length()) + s     // when s.length() < n
+```
+
+where `pads(pad, k)` is a recursive padding builder (`k` copies of the pad character). This single
+equality is properties 2 and 3 in one stroke — the output *is* the padding block followed by the
+original string, so the prefix is nothing but pad characters and the suffix is exactly `s`, by
+construction rather than by index arithmetic. The identity case (`s.length() >= n ==> result == s`)
+covers the no-padding side.
+
+Property 1 (the length) is **derived**, Verus-style: `padsLen` proves `|pads(pad, k)| == k` by
+induction on `k`, and `lengthTheorem` then concludes `|leftpad(pad, n, s)| == n` from the
+structural postcondition plus that lemma (length-of-concatenation is a theorem of the SMT
+sequence theory the verifier models strings with, so no axiom is needed).
+
+Two mechanical details formal-methods readers may enjoy: the induction hypothesis is just the
+method's own `@Ensures` at the recursive call, justified by the `@Decreases({ n - s.length() })`
+measure; and the recursion is deliberately shaped to prepend to the *result* — the
+accumulator-passing variant (`leftpad(pad, n, pad + s)`, the shape of this repo's functional Dafny
+entry) states the same structural equality only via a commutation lemma
+(`pad + pads(k) == pads(k) + pad`), which the result-prepending shape never needs.
+

--- a/groovy/leftpad.groovy
+++ b/groovy/leftpad.groovy
@@ -1,0 +1,44 @@
+import groovy.transform.TypeChecked
+import groovy.contracts.Requires
+import groovy.contracts.Ensures
+import groovy.contracts.Invariant
+import groovy.contracts.Decreases
+
+// Verified at COMPILE TIME by groovy-verify (https://github.com/paulk-asert/groovy-verify):
+// the @TypeChecked extension discharges every contract below with Z3 while javac-style
+// compilation runs — a wrong invariant or postcondition is a compile ERROR with a
+// concrete counterexample. groovy-contracts checks the same annotations at runtime.
+@TypeChecked(extensions = 'verification.VerifyChecker')
+class Leftpad {
+    @Requires({ s != null && n >= 0 })
+    @Ensures({ result.length == (n > s.length ? n : s.length) &&
+               (0..<(n > s.length ? n - s.length : 0)).every { int i -> result[i] == c } &&
+               (0..<s.length).every { int i -> result[(n > s.length ? n - s.length : 0) + i] == s[i] } })
+    static int[] leftpad(int c, int n, int[] s) {
+        int pad = n > s.length ? n - s.length : 0
+        int[] r = new int[pad + s.length]
+        int i = 0
+        @Invariant({ 0 <= i && i <= pad &&
+                     pad == (n > s.length ? n - s.length : 0) &&
+                     r.length == pad + s.length &&
+                     (0..<i).every { int q -> r[q] == c } })
+        @Decreases({ pad - i })
+        while (i < pad) {
+            r[i] = c
+            i = i + 1
+        }
+        int j = 0
+        @Invariant({ 0 <= j && j <= s.length &&
+                     pad == (n > s.length ? n - s.length : 0) &&
+                     r.length == pad + s.length &&
+                     (0..<pad).every { int q -> r[q] == c } &&
+                     (0..<j).every { int q -> r[pad + q] == s[q] } })
+        @Decreases({ s.length - j })
+        while (j < s.length) {
+            r[pad + j] = s[j]
+            j = j + 1
+        }
+        return r
+    }
+
+}

--- a/groovy/readme.md
+++ b/groovy/readme.md
@@ -1,0 +1,40 @@
+# [Groovy (groovy-verify)](https://github.com/paulk-asert/groovy-verify)
+
+An imperative proof of leftpad in [Apache Groovy](https://groovy.apache.org/), verified at
+**compile time** by [groovy-verify](https://github.com/paulk-asert/groovy-verify) — a static
+type-checking extension that discharges design-by-contract annotations with the Z3 SMT solver
+while ordinary compilation runs. There is no online demo yet; to reproduce, clone groovy-verify
+and run `./gradlew verify` — this exact proof is pinned in its test corpus (the
+`P207 sequential loops` group), and a broken invariant or postcondition fails compilation with a
+concrete counterexample.
+
+## About Groovy and groovy-verify
+
+Groovy is a JVM language — a close superset of Java with optional static typing. Its
+design-by-contract library ([groovy-contracts](https://groovy-lang.org/)) checks `@Requires` /
+`@Ensures` / loop `@Invariant` / `@Decreases` annotations **at runtime**. groovy-verify reuses
+those same stock annotations and proves them **statically**: it plugs into `@TypeChecked` (Groovy's
+static type checker is user-extensible), translates method bodies and contracts to SMT, and reports
+a failed proof as a compile error carrying a counterexample (Dafny-style), or an honest
+"skipped — outside the supported fragment" warning when it cannot model something. So the same
+annotations are checked twice: proved at compile time, and enforced at runtime as a second rung.
+
+## About the proof
+
+The specification on `leftpad` is the challenge's three properties, stated directly over the
+result array: the length is `max(n, len(s))`, every slot of the prefix equals the pad character,
+and the suffix is `s` element-for-element.
+
+The implementation is the classic two-loop form (fill the padding, then copy the string), and the
+proof is classic Hoare logic: each loop carries an `@Invariant` (established on entry, preserved by
+the body, conjoined with the negated guard on exit) and a `@Decreases` termination measure. The
+detail worth noticing is the second loop's invariant: it **restates** the first segment's fact
+(`(0..<pad).every { r[it] == c }`) — the second loop writes the same array, so anything the first
+loop established must be carried through the second loop's own invariant to survive. That is
+exactly the discipline JML's `maintaining` clauses impose in this repo's Java/OpenJML entry, which
+this proof is deliberately shaped after (Java is largely a syntactic subset of Groovy, so the two
+entries are line-for-line comparable).
+
+The quantified specification clauses (`(0..<k).every { ... }`) are ordinary Groovy — runnable
+closures over ranges — which the verifier reads as bounded universal quantifiers.
+


### PR DESCRIPTION
Two entries for **Apache Groovy**, both verified at **compile time** by [groovy-verify](https://github.com/paulk-asert/groovy-verify) — a static type-checking extension for Groovy's `@TypeChecked` that discharges the stock [groovy-contracts](https://groovy-lang.org/) design-by-contract annotations (`@Requires`/`@Ensures`/loop `@Invariant`/`@Decreases`) with the Z3 SMT solver during compilation. A broken invariant or postcondition is a compile **error with a concrete counterexample**; the same annotations are also enforced at runtime by groovy-contracts as a second rung.

**`groovy`** — the classic imperative two-loop form (fill the padding, copy the string), the three properties stated as index clauses over the result, proved Hoare-style with loop invariants and termination measures. Deliberately shaped after this repo's Java/OpenJML entry (Java being largely a syntactic subset of Groovy, the two are line-for-line comparable) — including the `maintaining`-style discipline of the second loop restating the first segment's fact.

**`groovy (functional)`** — recursion + induction, no loops or mutation. The spec is *structural*: `result == pads(pad, n - s.length()) + s` (with `pads` a recursive padding builder), which pins the prefix and suffix properties in a single equality; the length property is then *derived* from a `pads`-length lemma via a theorem method — the spec-fn/proof-fn structure of the Verus entry, done with plain methods (a method's own `@Ensures` at a recursive call is the induction hypothesis, justified by `@Decreases`).

Both proofs are pinned verbatim in groovy-verify's own test corpus (`./gradlew verify` reproduces them), and each README covers the tool, the proof, and the design choices (e.g. why the functional recursion prepends to the result rather than the accumulator — the latter needs a commutation lemma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)